### PR TITLE
fix(offscreen): only transfer control when possible

### DIFF
--- a/src/components/TouchSlider/TouchSlider.js
+++ b/src/components/TouchSlider/TouchSlider.js
@@ -46,8 +46,6 @@ const useOffscreenCanvasIfAvailable = (
     return;
   }
 
-  const supportsOffscreenCanvas = 'OffscreenCanvas' in window;
-
   const contextRef = useRef(null);
 
   // On mount
@@ -58,7 +56,7 @@ const useOffscreenCanvasIfAvailable = (
 
     // If the browser supports it, we want to allow the canvas to be painted
     // off of the main thread.
-    if (supportsOffscreenCanvas) {
+    if (typeof canvasRef.current === 'function') {
       canvasRef.current = canvasRef.current.transferControlToOffscreen();
     }
 

--- a/src/hooks/canvas.hook.js
+++ b/src/hooks/canvas.hook.js
@@ -63,6 +63,8 @@ const useCanvas = (
       return;
     }
 
+    // If the browser supports it, all we need to do is transfer control.
+    // The actual calculating and updating will happen in SlopesCanvas.worker.
     if (typeof canvasRef.current === 'function') {
       canvasRef.current = canvasRef.current.transferControlToOffscreen();
     } else {

--- a/src/hooks/canvas.hook.js
+++ b/src/hooks/canvas.hook.js
@@ -50,7 +50,6 @@ const useCanvas = (
   const worker = useWorker(WorkerConstructor);
 
   const devicePixelRatio = getDevicePixelRatio();
-  const supportsOffscreenCanvas = 'OffscreenCanvas' in window;
   const hasSentCanvas = React.useRef(false);
 
   // On mount, set up the worker message-handling
@@ -64,11 +63,7 @@ const useCanvas = (
       return;
     }
 
-    // If the browser supports it, all we need to do is transfer control.
-    // The actual calculating and updating will happen in SlopesCanvas.worker.
-    if (supportsOffscreenCanvas) {
-      // Canvas _does_ have transferControlToOffscreen if
-      // `supportsOffscreenCanvas` is true. $FlowIgnore
+    if (typeof canvasRef.current === 'function') {
       canvasRef.current = canvasRef.current.transferControlToOffscreen();
     } else {
       const context = canvasRef.current.getContext('2d');


### PR DESCRIPTION
fixes #51 

I looked into the code, and oddly, Safari does have OffscreenCanvas in window, but it doesn't have `transferControlToOffscreen` as a function on a canvas element (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/transferControlToOffscreen)).

I haven't tried this out yet, so will see what the preview gives