### PR TITLE
fix offscreencanvas detection

### DIFF
--- a/src/hooks/canvas.hook.js
+++ b/src/hooks/canvas.hook.js
@@ -52,6 +52,8 @@ const useCanvas = (
   const devicePixelRatio = getDevicePixelRatio();
   const hasSentCanvas = React.useRef(false);
 
+  const supportsOffscreenCanvas = typeof canvasRef.current === 'function';
+
   // On mount, set up the worker message-handling
   React.useEffect(() => {
     // If the user forgot to apply the canvas ref, we can't proceed.
@@ -65,7 +67,7 @@ const useCanvas = (
 
     // If the browser supports it, all we need to do is transfer control.
     // The actual calculating and updating will happen in SlopesCanvas.worker.
-    if (typeof canvasRef.current === 'function') {
+    if (supportsOffscreenCanvas) {
       canvasRef.current = canvasRef.current.transferControlToOffscreen();
     } else {
       const context = canvasRef.current.getContext('2d');


### PR DESCRIPTION
https://github.com/joshwcomeau/tinkersynth/pull/52 [broke the site](https://tinkersynth.com):

<img width="477" alt="Screen Shot 2019-05-04 at 5 32 18 PM" src="https://user-images.githubusercontent.com/6374832/57186363-95433100-6e92-11e9-94d3-291fe768b4ce.png">

This PR fixes it